### PR TITLE
Import the _ variable

### DIFF
--- a/backbone.collectionsubset.js
+++ b/backbone.collectionsubset.js
@@ -2,7 +2,7 @@
 * https://github.com/anthonyshort/backbone.collectionsubset
 * Copyright (c) 2012 Anthony Short; Licensed MIT */
 
-(function() {
+(function(_) {
 
   Backbone.CollectionSubset = (function() {
 
@@ -230,4 +230,4 @@
     module.exports = Backbone.CollectionSubset;
   }
 
-}).call(this);
+}).call(this, _);


### PR DESCRIPTION
This script blows up when the _.noconflict() method is in use. Importing the variable into the closure fixes it (and is a generally good practice anyway).
